### PR TITLE
chore: update .cspell.json ignorePaths and ignoreRegExpList

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -41,5 +41,20 @@
       "ignoreRegExpList": ["@author .*$", "[\\@]tparam", "\\author .*$", "Author(s)?( )?: .*$"]
     }
   ],
-  "words": []
+  "words": [
+    "buildtool",
+    "colcon",
+    "costmap",
+    "DCMAKE",
+    "GNUCXX",
+    "odometry",
+    "pkg",
+    "pkgs",
+    "rclcpp",
+    "rosdep",
+    "schematypens",
+    "vcstool",
+    "Wextra",
+    "Wpedantic"
+  ]
 }


### PR DESCRIPTION
SpellCheck CIが追加される以前に追加したファイルについてSpellCheck CIを通過するように設定を更新

Evidence: https://github.com/Fool-Stuck/wheel-stuck-ros-pkgs/actions/runs/9796981523