### PR TITLE
ci: add new word to spell check dictionary

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -43,9 +43,11 @@
   ],
   "words": [
     "buildtool",
+    "coef",
     "colcon",
     "costmap",
     "DCMAKE",
+    "Eigen",
     "GNUCXX",
     "odometry",
     "pkg",
@@ -54,7 +56,9 @@
     "rosdep",
     "schematypens",
     "vcstool",
+    "velodyne",
     "Wextra",
-    "Wpedantic"
+    "Wpedantic",
+    "XYZIR"
   ]
 }


### PR DESCRIPTION
以下の単語を辞書(.cspell.json)に追加

- coef : coefficient(係数)の略
- Eigen : ベクトル・行列演算ライブラリ名
- velodyne : LiDARテック企業名
- XYZIR : PointCloudの型の種類。座標値のXYZ、受光強度Intensity、レイヤ番号Ringの略