### PR TITLE
hotfix: swap vcs import and rosdep install

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -28,8 +28,8 @@ jobs:
           cd wheel_stuck_ws &&
           rosdep update &&
           apt-get update &&
-          rosdep install --from-path . -i -y --rosdistro ${{ matrix.rosdistro }} &&
-          vcs import src < depend_packages.repos
+          vcs import src < depend_packages.repos &&
+          rosdep install --from-path . -i -y --rosdistro ${{ matrix.rosdistro }}
 
       - name: Install diagnostic-updater
         run: apt-get install ros-${{ matrix.rosdistro }}-diagnostic-updater


### PR DESCRIPTION
build-and-testのCIにおいて、vcs importとrosdep installの順番が逆であった問題を修正