### PR TITLE
Improvement/axis params enum like

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 src/common/wheel_stuck_utils/** @Autumn60 @Bey9434
+src/control/joy2twist/** @Bey9434
 src/perception/velodyne_cloud_separator/** @Autumn60
 src/planning/dwa_planner/** @Autumn60
 src/sample/simple_int_publisher/** @Autumn60

--- a/src/control/joy2twist/config/joy2twist.param.yaml
+++ b/src/control/joy2twist/config/joy2twist.param.yaml
@@ -1,5 +1,5 @@
 /**:
   joy2twist:
     ros__parameters:
-      linear_x_axis: 1
-      angular_z_axis: 0
+      linear_x_axis: "LEFT_STICK_Y"
+      angular_z_axis: "LEFT_STICK_X"

--- a/src/control/joy2twist/include/joy2twist/joy2twist.hpp
+++ b/src/control/joy2twist/include/joy2twist/joy2twist.hpp
@@ -6,6 +6,9 @@
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <sensor_msgs/msg/joy.hpp>
 
+#include <string>
+#include <unordered_map>
+
 namespace joy2twist
 {
 using Joy = sensor_msgs::msg::Joy;
@@ -26,6 +29,11 @@ private:
 
   JoySubscription::SharedPtr joy_sub_;
   TwistStampedPublisher::SharedPtr twist_pub_;
+};
+
+const std::unordered_map<std::string, int> axis_map = {
+  {"LEFT_STICK_X", 0},  // 左スティックのX軸
+  {"LEFT_STICK_Y", 1}   // 左スティックのY軸
 };
 
 }  // namespace joy2twist

--- a/src/control/joy2twist/src/joy2twist.cpp
+++ b/src/control/joy2twist/src/joy2twist.cpp
@@ -1,13 +1,26 @@
 #include <joy2twist/joy2twist.hpp>
 
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+
 namespace joy2twist
 {
 
 Joy2Twist::Joy2Twist(const rclcpp::NodeOptions & options) : Node("joy2twist", options)
 {
+  // 軸名と数値のマッピング
+  std::unordered_map<std::string, int> axis_map = {
+    {"LEFT_STICK_X", 1},  // 左スティックのX軸
+    {"LEFT_STICK_Y", 0}   // 左スティックのY軸
+  };
   // パラメータの取得
-  linear_x_axis_ = declare_parameter<int>("linear_x_axis", 1);
-  angular_z_axis_ = declare_parameter<int>("angular_z_axis", 0);
+  std::string linear_x_axis_str = declare_parameter<std::string>("linear_x_axis", "LEFT_STICK_Y");
+  std::string angular_z_axis_str = declare_parameter<std::string>("angular_z_axis", "LEFT_STICK_X");
+
+  // 軸名を対応する数値に変換
+  linear_x_axis_ = axis_map.at(linear_x_axis_str);
+  angular_z_axis_ = axis_map.at(angular_z_axis_str);
 
   // 受信機を作る。型はjoyで受け取る。10個まで値が保持される。
   joy_sub_ = this->create_subscription<Joy>(

--- a/src/control/joy2twist/src/joy2twist.cpp
+++ b/src/control/joy2twist/src/joy2twist.cpp
@@ -1,8 +1,5 @@
 #include <joy2twist/joy2twist.hpp>
 
-#include <stdexcept>
-#include <string>
-
 namespace joy2twist
 {
 Joy2Twist::Joy2Twist(const rclcpp::NodeOptions & options) : Node("joy2twist", options)
@@ -33,7 +30,7 @@ void Joy2Twist::joy_callback(const Joy::SharedPtr msg)
   twist.twist.angular.z = static_cast<double>(angular_z);
 
   twist_pub_->publish(twist);
-};
+}
 
 }  // namespace joy2twist
 #include "rclcpp_components/register_node_macro.hpp"

--- a/src/control/joy2twist/src/joy2twist.cpp
+++ b/src/control/joy2twist/src/joy2twist.cpp
@@ -2,18 +2,11 @@
 
 #include <stdexcept>
 #include <string>
-#include <unordered_map>
 
 namespace joy2twist
 {
-
 Joy2Twist::Joy2Twist(const rclcpp::NodeOptions & options) : Node("joy2twist", options)
 {
-  // 軸名と数値のマッピング
-  std::unordered_map<std::string, int> axis_map = {
-    {"LEFT_STICK_X", 1},  // 左スティックのX軸
-    {"LEFT_STICK_Y", 0}   // 左スティックのY軸
-  };
   // パラメータの取得
   std::string linear_x_axis_str = declare_parameter<std::string>("linear_x_axis", "LEFT_STICK_Y");
   std::string angular_z_axis_str = declare_parameter<std::string>("angular_z_axis", "LEFT_STICK_X");
@@ -40,7 +33,7 @@ void Joy2Twist::joy_callback(const Joy::SharedPtr msg)
   twist.twist.angular.z = static_cast<double>(angular_z);
 
   twist_pub_->publish(twist);
-}
+};
 
 }  // namespace joy2twist
 #include "rclcpp_components/register_node_macro.hpp"


### PR DESCRIPTION
joy2twist.param.yamlのaxisパラメータをstringで与えられるように改善。
確認手順は以下のとおりです。

端末1
colcon build --packages-select joy2twist 
source install/setup.bash
ros2 launch joy2twist joy2twist.launch.xml

端末2
ros2 run joy joy_node

端末3
ros2 topic echo /turtle1/cmd_vel

の端末3でDualsenseの入力を確認しました。





