### PR TITLE
chore: update velodyne repository URL and version

### DIFF
--- a/depend_packages.repos
+++ b/depend_packages.repos
@@ -5,8 +5,8 @@ repositories:
     version: feature/ros2
   driver/velodyne:
     type: git
-    url: https://github.com/ros-drivers/velodyne.git
-    version: ros2
+    url: https://github.com/Autumn60/velodyne.git
+    version: ros2_hdl
   simulation/ros_tcp_endpoint:
     type: git
     url: https://github.com/Unity-Technologies/ROS-TCP-Endpoint


### PR DESCRIPTION
既存のVelodyneのリポジトリにはHDL32Eに対応したLaunchが無かったため、それらを追加したリポジトリにリンクを貼り替えた