### PR TITLE
rename point_types to point_xyzir

### DIFF
--- a/src/perception/velodyne_cloud_separator/include/velodyne_cloud_separator/point_xyzir.hpp
+++ b/src/perception/velodyne_cloud_separator/include/velodyne_cloud_separator/point_xyzir.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef VELODYNE_CLOUD_SEPARATOR__POINT_TYPES_HPP_
-#define VELODYNE_CLOUD_SEPARATOR__POINT_TYPES_HPP_
+#ifndef VELODYNE_CLOUD_SEPARATOR__POINT_XYZIR_HPP_
+#define VELODYNE_CLOUD_SEPARATOR__POINT_XYZIR_HPP_
 
 #include <pcl/point_types.h>
 
@@ -32,4 +32,4 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(
   pcl::PointXYZIR,
   (float, x, x)(float, y, y)(float, z, z)(float, intensity, intensity)(uint16_t, ring, ring))
 
-#endif  // VELODYNE_CLOUD_SEPARATOR__POINT_TYPES_HPP_
+#endif  // VELODYNE_CLOUD_SEPARATOR__POINT_XYZIR_HPP_

--- a/src/perception/velodyne_cloud_separator/include/velodyne_cloud_separator/velodyne_cloud_separator.hpp
+++ b/src/perception/velodyne_cloud_separator/include/velodyne_cloud_separator/velodyne_cloud_separator.hpp
@@ -15,7 +15,7 @@
 #ifndef VELODYNE_CLOUD_SEPARATOR__VELODYNE_CLOUD_SEPARATOR_HPP_
 #define VELODYNE_CLOUD_SEPARATOR__VELODYNE_CLOUD_SEPARATOR_HPP_
 
-#include "velodyne_cloud_separator/point_types.hpp"
+#include "velodyne_cloud_separator/point_xyzir.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 #include <wheel_stuck_common_utils/ros/function_timer.hpp>


### PR DESCRIPTION
velodyne_cloud_separatorのpoint_types.hppをpoint_xyzir.hppにリネームする #114