### PR TITLE
ci(spell-check): add "voxel" to cspell.json

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -67,6 +67,7 @@
     "urdf",
     "vcstool",
     "velodyne",
+    "voxel",
     "Wextra",
     "Wpedantic",
     "xacro",


### PR DESCRIPTION
grandfilterやpointcloud_preprocessor内で用いられるため