### PR TITLE
Fixed the structure of the joy2twist parameter

### DIFF
--- a/src/control/joy2twist/config/joy2twist.param.yaml
+++ b/src/control/joy2twist/config/joy2twist.param.yaml
@@ -1,5 +1,4 @@
 /**:
-  joy2twist:
-    ros__parameters:
-      linear_x_axis: "LEFT_STICK_Y"
-      angular_z_axis: "LEFT_STICK_X"
+  ros__parameters:
+    linear_x_axis: "LEFT_STICK_Y"
+    angular_z_axis: "LEFT_STICK_X"

--- a/src/control/joy2twist/src/joy2twist.cpp
+++ b/src/control/joy2twist/src/joy2twist.cpp
@@ -18,7 +18,7 @@ namespace joy2twist
 {
 Joy2Twist::Joy2Twist(const rclcpp::NodeOptions & options) : Node("joy2twist", options)
 {
-  // パラメータの取得
+  // パラメータの取得。
   std::string linear_x_axis_str = declare_parameter<std::string>("linear_x_axis", "LEFT_STICK_Y");
   std::string angular_z_axis_str = declare_parameter<std::string>("angular_z_axis", "LEFT_STICK_X");
 


### PR DESCRIPTION
joy2twistのパラメーター構造が間違っていたので修正しました。
cppでコメントを修正していますが、yamlのみでコミットするとPrettierに引っかかるためです。